### PR TITLE
Fix formatting in 6.4 upgrade recipe

### DIFF
--- a/download/upgradeRecipe/upgradeRecipe6.4.adoc
+++ b/download/upgradeRecipe/upgradeRecipe6.4.adoc
@@ -180,6 +180,7 @@ After in `*.java`:
 ----
 TerminationConfig clone = new TerminationConfig();
 clone.inherit(terminationConfig);
+----
 
 [.upgrade-recipe-minor]
 === `SwingUtils` and `SwingUncaughtExceptionHandler`: moved


### PR DESCRIPTION
The end of a code block is missing so the rest of the notes formatting is broken.